### PR TITLE
fix: use case-insensitive imports for TypeScript support

### DIFF
--- a/src/Leaflet.GeotagPhoto.Camera.js
+++ b/src/Leaflet.GeotagPhoto.Camera.js
@@ -1,4 +1,4 @@
-import L from 'Leaflet'
+import L from 'leaflet'
 import { fromFeature } from 'field-of-view'
 
 import GeotagPhotoCameraControl from './Leaflet.GeotagPhoto.CameraControl'

--- a/src/Leaflet.GeotagPhoto.CameraControl.js
+++ b/src/Leaflet.GeotagPhoto.CameraControl.js
@@ -1,4 +1,4 @@
-import L from 'Leaflet'
+import L from 'leaflet'
 
 export default L.Control.extend({
   options: {

--- a/src/Leaflet.GeotagPhoto.Crosshair.js
+++ b/src/Leaflet.GeotagPhoto.Crosshair.js
@@ -1,4 +1,4 @@
-import L from 'Leaflet'
+import L from 'leaflet'
 
 export default L.Evented.extend({
   options: {


### PR DESCRIPTION
Newer versions of TypeScript enforce case-sensitive imports. If using this package with another one which imports Leaflet the standard way, i.e. `import L from 'leaflet'`, you may get compile errors such as this:

![image](https://github.com/nypl-spacetime/Leaflet.GeotagPhoto/assets/18524052/6144828c-3105-4faa-b67a-2815471b5d8d)

Fix: import Leaflet with lowercase